### PR TITLE
[STEP-12] DB Lock 을 이용한 동시성 제어

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 
 	implementation("org.springframework.cloud:spring-cloud-starter-openfeign:4.2.0")
 
+	implementation("org.springframework.retry:spring-retry:2.0.11")
+
 	// Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
@@ -36,6 +36,9 @@ public class Coupon {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @Version
+    private int version;
+
     public void deductQuantity() {
         if (quantity <= 0) {
             throw new CouponOutOfStockException("쿠폰 재고가 부족합니다.");

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductOption.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductOption.java
@@ -37,6 +37,9 @@ public class ProductOption {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    @Version
+    private int version;
+
     public void deductQuantity(Long orderCount) {
         if (quantity < orderCount) {
             throw new ProductOptionOutOfStockException("선택한 상품 옵션의 재고가 부족합니다.");

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.domain.product;
 
+import jakarta.persistence.OptimisticLockException;
 import kr.hhplus.be.server.infrastructure.product.ProductOptionRepository;
 import kr.hhplus.be.server.infrastructure.product.ProductRepository;
 import kr.hhplus.be.server.infrastructure.product.ProductStatisticsRepository;
@@ -7,6 +8,8 @@ import kr.hhplus.be.server.interfaces.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,12 +66,14 @@ public class ProductService {
         return result;
     }
 
+    @Retryable(retryFor = OptimisticLockException.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     @Transactional
     public void deductQuantityWithLock(Long productOptionId, Long orderCount) {
         ProductOption findProductOption = productOptionRepository.findByIdWithLock(productOptionId).orElseThrow(() -> new NotFoundException("주문한 상품을 찾을 수 없습니다."));
         findProductOption.deductQuantity(orderCount);
     }
 
+    @Retryable(retryFor = OptimisticLockException.class, maxAttempts = 3, backoff = @Backoff(delay = 1000))
     @Transactional(readOnly = true)
     public ProductOption findByIdWithLock(Long productOptionId) {
         return productOptionRepository.findByIdWithLock(productOptionId).orElseThrow(() -> new NotFoundException("선택한 상품 옵션을 찾을 수 없습니다."));

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.READ)
     @Query("SELECT c FROM Coupon c WHERE c.couponId = :couponId")
     Optional<Coupon> findCouponByIdWithLock(@Param("couponId") Long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/MyCouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/MyCouponRepository.java
@@ -1,12 +1,14 @@
 package kr.hhplus.be.server.infrastructure.coupon;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.domain.coupon.MyCoupon;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
@@ -22,7 +24,8 @@ public interface MyCouponRepository extends JpaRepository<MyCoupon, Long> {
        """)
     Page<MyCoupon> findMyCoupons(@Param("memberId") Long memberId, Pageable pageable);
 
-    @Lock(LockModeType.PESSIMISTIC_READ)
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "10000")})
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
         SELECT mc
         FROM MyCoupon mc

--- a/src/main/java/kr/hhplus/be/server/infrastructure/order/OrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/order/OrderRepository.java
@@ -1,11 +1,9 @@
 package kr.hhplus.be.server.infrastructure.order;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.domain.order.Order;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
@@ -31,6 +29,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
         """)
     List<Order> findMyOrdersById(@Param("memberId") Long memberId);
 
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "10000")})
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
         SELECT o

--- a/src/main/java/kr/hhplus/be/server/infrastructure/payment/PaymentRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/payment/PaymentRepository.java
@@ -1,15 +1,18 @@
 package kr.hhplus.be.server.infrastructure.payment;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.domain.pay.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "10000")})
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""
         SELECT p

--- a/src/main/java/kr/hhplus/be/server/infrastructure/product/ProductOptionRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/product/ProductOptionRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.READ)
     @Query("""
         SELECT po
         FROM ProductOption po

--- a/src/main/java/kr/hhplus/be/server/infrastructure/wallet/WalletRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/wallet/WalletRepository.java
@@ -1,16 +1,18 @@
 package kr.hhplus.be.server.infrastructure.wallet;
 
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import kr.hhplus.be.server.domain.wallet.Wallet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface WalletRepository extends JpaRepository<Wallet, Long> {
-
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "10000")})
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT w FROM Wallet w WHERE w.memberId = :memberId")
     Optional<Wallet> findByIdWithLock(@Param("memberId")Long memberId);

--- a/src/test/java/kr/hhplus/be/server/application/BalanceFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/BalanceFacadeConcurrencyTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Transactional
 @SpringBootTest
 class BalanceFacadeConcurrencyTest {
 
@@ -21,6 +20,7 @@ class BalanceFacadeConcurrencyTest {
 
     @DisplayName("한 회원에게 1000원씩 10회 동시에 충전할 경우, 총 10000원 충전됌")
     @Test
+    @Transactional
     void chargeConcurrentTest() throws InterruptedException {
         int threadCount = 10;
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/src/test/java/kr/hhplus/be/server/application/CouponFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/CouponFacadeConcurrencyTest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Transactional
 @SpringBootTest
 class CouponFacadeConcurrencyTest {
 
@@ -29,6 +28,7 @@ class CouponFacadeConcurrencyTest {
 
     @DisplayName("한 회원에게 쿠폰 발급을 10회 동시에 요청할 경우, 해당 유저에게 쿠폰 총 10개가 발급되며 쿠폰 재고가 10개 차감됌")
     @Test
+    @Transactional
     void issueCouponConcurrencyTest() throws InterruptedException {
         int threadCount = 10;
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/src/test/java/kr/hhplus/be/server/application/OrderFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/OrderFacadeConcurrencyTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Transactional
 @SpringBootTest
 class OrderFacadeConcurrencyTest {
 
@@ -33,6 +32,7 @@ class OrderFacadeConcurrencyTest {
 
     @DisplayName("한 회원이 동시에 10회 주문 요청할 경우, 주문 10회 생성 및 상품 재고 20개 차감")
     @Test
+    @Transactional
     void orderConcurrencyTest() throws InterruptedException {
         int threadCount = 10;
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/src/test/java/kr/hhplus/be/server/application/PayFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/PayFacadeConcurrencyTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Transactional
 @SpringBootTest
 class PayFacadeConcurrencyTest {
 
@@ -43,6 +42,7 @@ class PayFacadeConcurrencyTest {
 
     @DisplayName("한 주문에 대한 결제 요청을 동시에 10회 처리할 경우, 1건 결제 성공(그외 9건 중복 예외 발생) 및 유저 쿠폰 사용처리")
     @Test
+    @Transactional
     void orderConcurrencyTest() throws InterruptedException {
         int threadCount = 10;
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
@@ -35,7 +35,7 @@ class CouponServiceTest {
 
     @Test
     void 쿠폰조회_성공() {
-        Coupon coupon = new Coupon(1L, "쿠폰1", DiscountType.RATE.name(), 10L, 10L, LocalDateTime.now(), LocalDateTime.now());
+        Coupon coupon = new Coupon(1L, "쿠폰1", DiscountType.RATE.name(), 10L, 10L, LocalDateTime.now(), LocalDateTime.now(), 0);
         when(couponRepository.findById(1L)).thenReturn(Optional.of(coupon));
 
         Coupon findCoupon = couponService.findCouponById(1L);
@@ -54,7 +54,7 @@ class CouponServiceTest {
     @Test
     void 선착순쿠폰발급_성공() {
         Member member = Member.of(1L, "홍길동");
-        Coupon coupon = new Coupon(1L, "선착순쿠폰", DiscountType.RATE.name(), 10L, 5L, LocalDateTime.now(), LocalDateTime.now());
+        Coupon coupon = new Coupon(1L, "선착순쿠폰", DiscountType.RATE.name(), 10L, 5L, LocalDateTime.now(), LocalDateTime.now(), 0);
         when(couponRepository.findCouponByIdWithLock(1L)).thenReturn(Optional.of(coupon));
         when(myCouponRepository.save(any(MyCoupon.class))).thenReturn(any(MyCoupon.class));
 


### PR DESCRIPTION
### PR 설명
코드의 DB Lock 제어 부분을 개선 작업한 PR입니다.

---  

### **커밋 링크**
상품, 쿠폰 재고 lock mode 변경(낙관적락): a92a592a
비관적락 타임아웃 설정: 9679bb46

---

### **리뷰 포인트(질문)**
- 데드락 방지용 코드로 타임아웃을 설정하는 것 외에 더 효과적인 방법이 있는지 궁금합니다.
- 한 트랜잭션 범위에서 낙관적락과 비관적락을 혼합해서 사용하는 건 잘못된 접근인지 궁금합니다.

---

### Definition of Done (DoD)
- [x] DB lock 적용
- [x] 재시도 정책 반영
- [x] 데드락 방지용 타임아웃 처리
- [ ] 동시성 테스트코드 추가 작성 및 리팩토링
